### PR TITLE
Add --build-dir to specify where built files should be placed

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -33,6 +33,8 @@ import shutil
 parser = argparse.ArgumentParser('Configures the project.')
 parser.add_argument('--spcomp-dir',
 		help = 'Directory with the SourcePawn compiler.  Will check PATH if not specified.')
+parser.add_argument('--build-dir',
+		help = 'Directory to put build files. Will be ./build if not specified.')
 
 args = parser.parse_args()
 
@@ -60,7 +62,7 @@ with contextlib.closing(ninja_syntax.Writer(open('build.ninja', 'wt'))) as build
 	vars = {
 		'configure_args': sys.argv[1:],
 		'root': '.',
-		'builddir': 'build',
+		'builddir': args.build_dir or 'build',
 		'spcomp': spcomp,
 		'spcflags': [ '-i${root}/scripting/include', '-h', '-v0' ]
 	}


### PR DESCRIPTION
Useful for me as I test things locally so 
`>python3 configure.py --spcomp-dir "L:\tf2server\steamapps\common\Team Fortress 2 Dedicated Server\tf\addons\sourcemod\scripting" --build-dir "L:\tf2server\steamapps\common\Team Fortress 2 Dedicated Server\tf\addons\sourcemod"`

allows me to copy all built files where they should be. In a perfect world, maybe there could be some argument like --local which would only specify one sourcemod directory and then read spcomp and place built files in there? idk lol i just figured that other ppl might find this two line change useful