### PR TITLE
Preserve directory names with spaces in resulting build file

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -58,7 +58,8 @@ with contextlib.closing(ninja_syntax.Writer(open('build.ninja', 'wt'))) as build
 	build.newline()
 	
 	vars = {
-		'configure_args': sys.argv[1:],
+		'configure_args': ' '.join(f'--{k.replace( "_", "-")} \"{v}\"' for k, v in vars(args).items()), # this is ugly but essentially this looks through all the arguments, adds quotes around the value of the argument, and changes underscores to dashes in the name of the argument 
+		# this is so that command line arguments that contain directories with spaces are correctly preserved in the build file
 		'root': '.',
 		'builddir': 'build',
 		'spcomp': spcomp,


### PR DESCRIPTION
It's a kinda hacky solution, but this fixes some problems where generated build files with fail as the command line arguments put into the file lack the quotes that the initial setup arguments had.

For example 
`python3 configure.py --spcomp-dir "L:\tf2server\steamapps\common\Team Fortress 2 Dedicated Server\tf\addons\sourcemod\scripting"`
results in 
```
configure_args = --spcomp-dir L:\tf2server\steamapps\common\Team Fortress 2 $
    Dedicated Server\tf\addons\sourcemod\scripting
```
being written to the build file, which will result in 

```
FAILED: build.ninja
Configures the project.: error: unrecognized arguments: Fortress 2 Dedicated Server\tf\addons\sourcemod\scripting Fortress 2 Dedicated Server\tf\addons\sourcemod
```
