### PR TITLE
Write exact directory when generating build file

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -59,13 +59,13 @@ with contextlib.closing(ninja_syntax.Writer(open('build.ninja', 'wt'))) as build
 	
 	vars = {
 		'configure_args': sys.argv[1:],
-		'root': '.',
+		'root': sys.path[0],
 		'builddir': 'build',
 		'spcomp': spcomp,
 		'spcflags': [ '-i${root}/scripting/include', '-h', '-v0' ]
 	}
 	
-	vars['spcflags'] += ('-i{}'.format(d) for d in include_dirs)
+	vars['spcflags'] += (f'-i{sys.path[0]}/{d}' for d in include_dirs)
 	
 	for key, value in vars.items():
 		build.variable(key, value)


### PR DESCRIPTION
Running build.ninja using the -f flag in ninja from any other directory other than the directory it was originally configured in fails as it can't find the referenced includes. For example:

```
C:\Users\Charlotte>ninja -f l:\SM-TFCWXBaseAttributes\build.ninja
[1/2] Compiling "L:\tf2server\steamapps\common\Team Fortre...Server\tf\addons\sourcemod\plugins\viewmodel_override.smx"
FAILED: L:/tf2server/steamapps/common/Team Fortress 2 Dedicated Server/tf/addons/sourcemod/plugins/viewmodel_override.smx
L:\tf2server\steamapps\common\Team Fortress 2 Dedicated Server\tf\addons\sourcemod\scripting\spcomp.EXE L:\SM-TFCWXBaseAttributes\scripting\viewmodel_override.sp -iL:\SM-TFCWXBaseAttributes/scripting/include -h -v0 -ithird_party/include_submodules -ithird_party/vendored -o "L:\tf2server\steamapps\common\Team Fortress 2 Dedicated Server\tf\addons\sourcemod\plugins\viewmodel_override.smx"
L:\SM-TFCWXBaseAttributes\scripting\viewmodel_override.sp(23) : fatal error 183: cannot read from file: "stocksoup/tf/entity_prop_stocks"

Compilation aborted.
1 Error.
```

This fixes that, but it might be worth hiding this behind another command line argument, like --portable, as it does make resulting build files look ugly. 